### PR TITLE
Add another engine.

### DIFF
--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/skx/evalfilter"
+)
+
+func Benchmark_evalfilter(b *testing.B) {
+
+	var ret bool
+	var err error
+
+	params := createParams()
+
+	// Script we run has to be modified a little to make
+	// it into filter which returns true/false.
+	src := `if ( (Origin == "MOW" || Country == "RU") && (Value >= 100 || Adults == 1) ) { return true; } else { return false; }`
+
+	eval := evalfilter.New(src)
+
+	err = eval.Prepare()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ret, err = eval.Run(params)
+	}
+	b.StopTimer()
+
+	if err != nil {
+		b.Fatal(err)
+	}
+	if !ret {
+		b.Fail()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/google/cel-go v0.2.0
 	github.com/hashicorp/go-bexpr v0.1.0
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
-	github.com/skx/evalfilter v0.0.0-20191103115105-876237ff5e32
+	github.com/skx/evalfilter v2.0.0
 	go.starlark.net v0.0.0-20190604130855-6ddc71c0ba77
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/cel-go v0.2.0
 	github.com/hashicorp/go-bexpr v0.1.0
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
+	github.com/skx/evalfilter v0.0.0-20191103115105-876237ff5e32
 	go.starlark.net v0.0.0-20190604130855-6ddc71c0ba77
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )


### PR DESCRIPTION
This pull-request adds a new evaluation engine to your benchmark list:

* https://github.com/skx/evalfilter

Although it isn't the slowest it almost is!  I appreciate different systems will have different numbers but for reference here is what I see:

```
$ go test -bench=. -benchtime=20s
goos: linux
goarch: amd64
pkg: github.com/antonmedv/golang-expression-evaluation-comparison
Benchmark_bexpr-4              	30000000	      1099 ns/op
Benchmark_celgo-4              	50000000	       505 ns/op
Benchmark_celgo_startswith-4   	50000000	       742 ns/op
Benchmark_evalfilter-4         	10000000	      4749 ns/op
Benchmark_expr-4               	100000000	       302 ns/op
Benchmark_expr_startswith-4    	50000000	       571 ns/op
Benchmark_goja-4               	50000000	       542 ns/op
Benchmark_govaluate-4          	50000000	       523 ns/op
Benchmark_gval-4               	 2000000	     16857 ns/op
Benchmark_otto-4               	20000000	      1965 ns/op
Benchmark_starlark-4           	 2000000	     12561 ns/op
PASS
ok  	github.com/antonmedv/golang-expression-evaluation-comparison	394.172s
```