### PR TITLE
Added evalfilter example.

### DIFF
--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/skx/evalfilter/v2"
+)
+
+func Benchmark_evalfilter(b *testing.B) {
+
+	var ret bool
+	var err error
+
+	params := createParams()
+
+	// Script we run has to be modified a little, to turn it into a
+	// filter with a boolean return-value.
+	src := `if ( (Origin == "MOW" || Country == "RU") && (Value >= 100 || Adults == 1) ) { return true; } else { return false; }`
+
+	eval := evalfilter.New(src)
+
+	err = eval.Prepare()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ret, err = eval.Run(params)
+	}
+	b.StopTimer()
+
+	if err != nil {
+		b.Fatal(err)
+	}
+	if !ret {
+		b.Fail()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/google/cel-go v0.2.0
 	github.com/hashicorp/go-bexpr v0.1.0
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
-	github.com/skx/evalfilter v1.5.2
 	github.com/skx/evalfilter/v2 v2.1.2
 	go.starlark.net v0.0.0-20190604130855-6ddc71c0ba77
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,9 @@ require (
 	github.com/google/cel-go v0.2.0
 	github.com/hashicorp/go-bexpr v0.1.0
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
+	github.com/skx/evalfilter v1.5.2
+	github.com/skx/evalfilter/v2 v2.1.2
 	go.starlark.net v0.0.0-20190604130855-6ddc71c0ba77
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.2.5 // indirect
 )


### PR DESCRIPTION
This pull-request adds [evalfilter](https://github.com/skx/evalfilter/) to the benchmark, replacing the previous pull-request of #2 

Once applied usage looks like this:

```
$ go test -bench=. -benchtime=1s
go: downloading github.com/skx/evalfilter/v2 v2.1.2
go: extracting github.com/skx/evalfilter/v2 v2.1.2
go: finding github.com/skx/evalfilter/v2 v2.1.2
goos: linux
goarch: amd64
pkg: github.com/antonmedv/golang-expression-evaluation-comparison
Benchmark_bexpr-4              	 1675444	       699 ns/op
Benchmark_celgo-4              	 3616413	       342 ns/op
Benchmark_celgo_startswith-4   	 2506464	       478 ns/op
Benchmark_evalfilter-4         	  629077	      1801 ns/op
Benchmark_expr-4               	 6396127	       191 ns/op
Benchmark_expr_startswith-4    	 3416218	       400 ns/op
Benchmark_goja-4               	 3259450	       427 ns/op
Benchmark_govaluate-4          	 3436450	       341 ns/op
Benchmark_gval-4               	  134576	      8411 ns/op
Benchmark_otto-4               	 1000000	      1040 ns/op
Benchmark_starlark-4           	  197200	      5981 ns/op
PASS
ok  	github.com/antonmedv/golang-expression-evaluation-comparison	16.311s
```

Here you see the module was downloaded successfully this time!